### PR TITLE
Docs for granular proxy mode

### DIFF
--- a/docs/server/channels.md
+++ b/docs/server/channels.md
@@ -182,6 +182,14 @@ History recovery mechanism if enabled will continue to work for clients anyway e
 
 `proxy_publish` (boolean, default `false`) – turns on publish proxy, more info in [proxy chapter](proxy.md)
 
+### subscribe_proxy_name
+
+`subscribe_proxy_name` (string, default `""`) – turns on subscribe proxy when [granular proxy mode](proxy.md#granular-proxy-mode) is used. Note that `proxy_subscribe` option defined above is ignored in granular proxy mode.
+
+### publish_proxy_name
+
+`publish_proxy_name` (string, default `""`) – turns on publish proxy when [granular proxy mode](proxy.md#granular-proxy-mode) is used. Note that `proxy_publish` option defined above is ignored in granular proxy mode.
+
 ## Channel options config example
 
 Let's look at how to set some of these options in a config:

--- a/docs/server/load_balancing.md
+++ b/docs/server/load_balancing.md
@@ -1,6 +1,6 @@
 ---
 id: load_balancing
-title: Load Balancing
+title: Load balancing
 ---
 
 This chapter shows how to deal with persistent connection load balancing.

--- a/docs/server/proxy.md
+++ b/docs/server/proxy.md
@@ -5,8 +5,6 @@ title: Proxy to backend
 
 It's possible to proxy some client connection events from Centrifugo to the application backend and react to them in a custom way. For example, it's possible to authenticate connection via request from Centrifugo to application backend, refresh client sessions and answer to RPC calls sent by a client over bidirectional connection.
 
-## Proxy overview
-
 The list of events that can be proxied:
 
 * Connect – called when a client connects to Centrifugo, so it's possible to authenticate user, return custom data to a client, attach meta information to the connection, and so on. Works for bidirectional and unidirectional transports.
@@ -707,12 +705,12 @@ Centrifugo v3.1.0 introduced a new mode for proxy configuration called granular 
 
 ### Enable granular proxy mode
 
-Since the change is rather radical it requires a separate boolean option `use_granular_proxies` to be enabled. As soon as this option set Centrifugo does not use proxy configuration rules described above and follows the rules described below.
+Since the change is rather radical it requires a separate boolean option `granular_proxy_mode` to be enabled. As soon as this option set Centrifugo does not use proxy configuration rules described above and follows the rules described below.
 
 ```json title="config.json"
 {
   ...
-  "use_granular_proxies": true
+  "granular_proxy_mode": true
 }
 ```
 
@@ -725,7 +723,7 @@ Here is an example:
 ```json title="config.json"
 {
   ...
-  "use_granular_proxies": true,
+  "granular_proxy_mode": true,
   "proxies": [
     {
       "name": "connect",
@@ -799,7 +797,18 @@ To enable connect proxy:
 ```json title="config.json"
 {
   ...
-  "use_granular_proxies": true,
+  "granular_proxy_mode": true,
+  "proxies": [...],
+  "connect_proxy_name": "connect"
+}
+```
+
+Let's also add refresh proxy:
+
+```json title="config.json"
+{
+  ...
+  "granular_proxy_mode": true,
   "proxies": [...],
   "connect_proxy_name": "connect",
   "refresh_proxy_name": "refresh"
@@ -808,12 +817,12 @@ To enable connect proxy:
 
 ### Granular subscribe and publish
 
-Subscribe and publish proxy work per-namespace. This means that `subscribe_proxy_name` and `publish_proxy_name` are just a channel namespace options. So it's possible to define these options on congiguration top-level (for channels in default top-level namespace) or inside namespace object.
+Subscribe and publish proxy work per-namespace. This means that `subscribe_proxy_name` and `publish_proxy_name` are just a channel namespace options. So it's possible to define these options on configuration top-level (for channels in default top-level namespace) or inside namespace object.
 
 ```json title="config.json"
 {
   ...
-  "use_granular_proxies": true,
+  "granular_proxy_mode": true,
   "proxies": [...],
   "namespaces": [
     {
@@ -847,7 +856,7 @@ Analogous to channel namespaces it's possible to configure rpc namespaces:
 ```json title="config.json"
 {
   ...
-  "use_granular_proxies": true,
+  "granular_proxy_mode": true,
   "proxies": [...],
   "namespaces": [...],
   "rpc_namespaces": [

--- a/docs/server/proxy.md
+++ b/docs/server/proxy.md
@@ -821,11 +821,13 @@ Subscribe and publish proxy work per-namespace. This means that `subscribe_proxy
     {
       "name": "ns1",
       "subscribe_proxy_name": "subscribe1",
+      "publish": true,
       "publish_proxy_name": "publish1"
     },
     {
       "name": "ns2",
       "subscribe_proxy_name": "subscribe2",
+      "publish": true,
       "publish_proxy_name": "publish2"
     }
   ]

--- a/docs/server/proxy.md
+++ b/docs/server/proxy.md
@@ -803,6 +803,8 @@ To enable connect proxy:
 }
 ```
 
+We have an [example of Centrifugo integration with NodeJS](https://github.com/centrifugal/examples/tree/master/nodejs_granular_proxy) which uses granular proxy mode. Even if you are not using NodeJS on a backend an example can help you understand the idea.
+
 Let's also add refresh proxy:
 
 ```json title="config.json"

--- a/docs/server/proxy.md
+++ b/docs/server/proxy.md
@@ -716,7 +716,7 @@ Since the change is rather radical it requires a separate boolean option `granul
 
 ### Defining a list of proxies
 
-When using granular proxy mode on configuration top level you can define `"proxies"` array with a list of different proxy objects. Each proxy object in an array should have at least three required fields: `name`, `type` and `endpoint`.
+When using granular proxy mode on configuration top level you can define `"proxies"` array with a list of different proxy objects. Each proxy object in an array should have at least two required fields: `name` and `endpoint`.
 
 Here is an example:
 
@@ -727,46 +727,38 @@ Here is an example:
   "proxies": [
     {
       "name": "connect",
-      "type": "http",
       "endpoint": "http://localhost:3000/centrifugo/connect",
       "timeout": "500ms",
       "http_headers": ["Cookie"]
     },
     {
       "name": "refresh",
-      "type": "http",
       "endpoint": "http://localhost:3000/centrifugo/refresh",
       "timeout": "500ms"
     },
     {
       "name": "subscribe1",
-      "type": "http",
       "endpoint": "http://localhost:3001/centrifugo/subscribe"
     },
     {
       "name": "publish1",
-      "type": "http",
       "endpoint": "http://localhost:3001/centrifugo/publish"
     },
     {
       "name": "rpc1",
-      "type": "http",
       "endpoint": "http://localhost:3001/centrifugo/rpc"
     },
     {
       "name": "subscribe2",
-      "type": "http",
       "endpoint": "http://localhost:3002/centrifugo/subscribe"
     },
     {
       "name": "publish2",
-      "type": "http",
-      "endpoint": "http://localhost:3002/centrifugo/publish"
+      "endpoint": "grpc://localhost:3002"
     }
     {
       "name": "rpc2",
-      "type": "http",
-      "endpoint": "http://localhost:3002/centrifugo/rpc"
+      "endpoint": "grpc://localhost:3002"
     }
   ]
 }
@@ -777,8 +769,7 @@ Let's look at all fields for a proxy object which is possible to set for each pr
 | Field name | Field type | Required | Description  |
 | -------------- | -------------- | ------------ | ---- |
 | name       | string  | yes | Unique name of proxy used for referencing in configuration, must match regexp `^[-a-zA-Z0-9_.]{2,}$`      |
-| type       | string  | yes | Type of proxy: `http` or `grpc`       |
-| endpoint       | string  | yes | HTTP or GRPC endpoint (same format as in default proxy mode)      |
+| endpoint       | string  | yes | HTTP or GRPC endpoint in the same format as in default proxy mode. For example, `http://localhost:3000/path` for HTTP or `grpc://localhost:3000` for GRPC.      |
 | timeout       | duration (string)  | no | Proxy request timeout, default `"1s"`       |
 | http_headers       | array of strings  | no | List of headers to proxy, by default no headers       |
 | grpc_metadata       | array of strings  | no | List of GRPC metadata keys to proxy, by default no metadata keys   |
@@ -786,7 +777,7 @@ Let's look at all fields for a proxy object which is possible to set for each pr
 | include_connection_meta | bool  | no | Include meta information (attached on connect)       |
 | grpc_cert_file       | string  | no | Path to cert file for secure TLS connection. If not set then an insecure connection with the backend endpoint is used.       |
 | grpc_credentials_key       | string  | no | Add custom key to per-RPC credentials.       |
-| grpc_credentials_value       | string  | no | A custom value for `proxy_grpc_credentials_key`.       |
+| grpc_credentials_value       | string  | no | A custom value for `grpc_credentials_key`.       |
 
 ### Granular connect and refresh
 


### PR DESCRIPTION
Subj, relates https://github.com/centrifugal/centrifugo/issues/477

- [x] One thing I consider to change is rename `use_granular_proxies` option to `granular_proxy_mode`.
- [x] Also need to check that `proxy_subscribe` and `proxy_publish` not used when granular proxy mode on.