### PR TITLE
Install script for easy installation

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -5,6 +5,10 @@ title: Install Centrifugo
 
 Centrifugo server is written in Go language. It's an open-source software, the source code is available [on Github](https://github.com/centrifugal/centrifugo).
 
+```shell
+curl -sSLf https://centrifugal.dev/install.sh | sh
+```
+
 ## Install from the binary release
 
 For a local development the simplest way to get Centrifugo is from binary release (i.e. single all-contained executable file).

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -5,13 +5,9 @@ title: Install Centrifugo
 
 Centrifugo server is written in Go language. It's an open-source software, the source code is available [on Github](https://github.com/centrifugal/centrifugo).
 
-```shell
-curl -sSLf https://centrifugal.dev/install.sh | sh
-```
-
 ## Install from the binary release
 
-For a local development the simplest way to get Centrifugo is from binary release (i.e. single all-contained executable file).
+For a local development you can download prebuilt Centrifugo binary release (i.e. single all-contained executable file) for your system.
 
 Binary releases available on Github. [Download latest release](https://github.com/centrifugal/centrifugo/releases) for your operating system, unpack it and you are done. Centrifugo is pre-built for:
 
@@ -27,7 +23,13 @@ Binary releases available on Github. [Download latest release](https://github.co
 Archives contain a single statically compiled binary `centrifugo` file that is ready to run: 
 
 ```
-./centrifugo -h
+./centrifugo
+```
+
+If you doubt which distribution you need, then on Linux or MacOS you can use the following command to download and unpack `centrifugo` binary to your current working directory:
+
+```shell
+curl -sSLf https://centrifugal.dev/install.sh | sh
 ```
 
 See the version of Centrifugo:

--- a/static/install.sh
+++ b/static/install.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+set -e
+
+if [ -n "${DEBUG}" ]; then
+  set -x
+fi
+
+_centrifugo_latest() {
+  curl -s https://api.github.com/repos/centrifugal/centrifugo/releases/latest | grep "tag_name" | awk '{print $2}' | sed 's/[",]//g'
+}
+
+_detect_binary() {
+  os="$(uname)"
+  case "$os" in
+    Linux|Darwin) echo "centrifugo" ;;
+    *) echo "Unsupported operating system: $os" 1>&2; return 1 ;;
+  esac
+  unset os
+}
+
+_detect_os() {
+  os="$(uname)"
+  case "$os" in
+    Linux) echo "linux" ;;
+    Darwin) echo "darwin" ;;
+    *) echo "Unsupported operating system: $os" 1>&2; return 1 ;;
+  esac
+  unset os
+}
+
+_detect_arch() {
+  arch="$(uname -m)"
+  case "$arch" in
+    amd64|x86_64) echo "amd64" ;;
+    arm64|aarch64) echo "arm64" ;;
+    *) echo "Unsupported processor architecture: $arch" 1>&2; return 1 ;;
+  esac
+  unset arch
+}
+
+_download_url() {
+  echo "https://github.com/centrifugal/centrifugo/releases/download/$CENTRIFUGO_VERSION/${centrifugoBinary}_${CENTRIFUGO_VERSION#"v"}_${centrifugoOs}_${centrifugoArch}.tar.gz"
+}
+
+main() {
+  if [ -z "${CENTRIFUGO_VERSION}" ]; then
+    CENTRIFUGO_VERSION=$(_centrifugo_latest)
+  fi
+
+#  centrifugoInstallPath=/usr/local/bin
+  centrifugoInstallPath=`pwd`
+  centrifugoBinary="$(_detect_binary)"
+  centrifugoOs="$(_detect_os)"
+  centrifugoArch="$(_detect_arch)"
+  centrifugoDownloadUrl="$(_download_url)"
+
+  mkdir -p -- "$centrifugoInstallPath"
+
+  echo "Downloading centrifugo from URL: $centrifugoDownloadUrl"
+
+  curl -sSLf "$centrifugoDownloadUrl" >"/tmp/centrifugo.tar.gz"
+  tar -xzf /tmp/centrifugo.tar.gz ${centrifugoBinary}
+  chmod +x "$centrifugoBinary"
+
+  echo "centrifugo is now executable in $centrifugoInstallPath"
+}
+
+main

--- a/static/install.sh
+++ b/static/install.sh
@@ -48,7 +48,6 @@ main() {
     CENTRIFUGO_VERSION=$(_centrifugo_latest)
   fi
 
-#  centrifugoInstallPath=/usr/local/bin
   centrifugoInstallPath=`pwd`
   centrifugoBinary="$(_detect_binary)"
   centrifugoOs="$(_detect_os)"
@@ -59,9 +58,11 @@ main() {
 
   echo "Downloading centrifugo from URL: $centrifugoDownloadUrl"
 
-  curl -sSLf "$centrifugoDownloadUrl" >"/tmp/centrifugo.tar.gz"
+  tmpdir=$(mktemp -d)
+  curl -sSLf "$centrifugoDownloadUrl" >"$tmpdir/centrifugo.tar.gz"
   tar -xzf /tmp/centrifugo.tar.gz ${centrifugoBinary}
   chmod +x "$centrifugoBinary"
+  rm -r $tmpdir
 
   echo "centrifugo is now executable in $centrifugoInstallPath"
 }


### PR DESCRIPTION
The change adds an install script for easy installation. 

The script downloads the tar.gz and extracts the binary to the current workdir. We can install it directly to `/usr/local/bin`, but then `sudo` is required to execute the script.

Installation docs are updated:

![kuva](https://user-images.githubusercontent.com/557879/209128256-4e6c0958-74cb-4b5d-8ba1-8f78e3ec8a65.png)
