### PR TITLE
Fix typo: client.connect / client.Connect

### DIFF
--- a/docs/transports/client_api.md
+++ b/docs/transports/client_api.md
@@ -621,7 +621,7 @@ if err != nil {
 	log.Fatalln(err)
 }
 
-if err = client.connect(); err != nil {
+if err = client.Connect(); err != nil {
     log.Fatalln(err)
 }
 ```


### PR DESCRIPTION
Method `client.Connect` is public, so must be capitalized