### PR TITLE
Use latest Docker Compose best practices

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -115,7 +115,6 @@ Create configuration file `config.json`:
 Create `docker-compose.yml`:
 
 ```yml
-version: "3.9"
 services:
   centrifugo:
     container_name: centrifugo
@@ -134,7 +133,7 @@ services:
 Run with:
 
 ```
-docker-compose up
+docker compose up
 ```
 
 ## Kubernetes Helm chart


### PR DESCRIPTION
Just two little things I noticed:
* `version` is deprecated in `docker-compose.yml`
* `docker-compose` is deprecated and `docker compose` should be used instead