### PR TITLE
Fix typos in docs/getting-started/introduction.md

### DIFF
--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -5,7 +5,7 @@ title: Centrifugo introduction
 
 <img src="/img/logo_animated_no_accel.svg" width="100px" height="100px" align="left" style={{'marginRight': '10px', 'float': 'left'}} />
 
-Centrifugo is an open-source real-time messaging server. Centrifugo can instantly deliver messages to application online users connected over supported transports – WebSocket, HTTP-streaming, Server-Sent Events (SSE), WebTransport, GRPC. Centrifugo is built around channel concept – clients subscribe to channels to receive publications, different subscriptions are multiplexed over a single connection to the server. So Centrifugo is a user-facing PUB/SUB server, with many additional features around this core concept.
+Centrifugo is an open-source real-time messaging server. Centrifugo can instantly deliver messages to the application's online users connected over supported transports – WebSocket, HTTP-streaming, Server-Sent Events (SSE), WebTransport, GRPC. Centrifugo is built around the channel concept – clients subscribe to channels to receive publications, different subscriptions are multiplexed over a single connection to the server. So Centrifugo is a user-facing PUB/SUB server, with many additional features around this core concept.
 
 :::tip Prefer podcast format? (22 MB)
 


### PR DESCRIPTION
This PR fixes grammatical issues in the introduction document by adding missing articles in the first paragraph:

- Added "the" and apostrophe in "to the application's online users" (was "to application online users")
- Added "the" in "built around the channel concept" (was "built around channel concept")

Resolves #73

Generated with [Claude Code](https://claude.ai/code)