### PR TITLE
docs(pro): rate limiting - dry run, per-IP connect limit, metrics

### DIFF
--- a/docs/pro/rate_limiting.md
+++ b/docs/pro/rate_limiting.md
@@ -6,7 +6,9 @@ title: Operation rate limits
 
 The rate limit feature allows limiting the number of operations each connection or user can issue during a configured time interval. This is useful to protect the system from misuse, and for detecting and disconnecting abusive or broken (due to a bug in the frontend application) clients that add unwanted load on a server.
 
-With rate limit properly configured, you can protect your Centrifugo installation to some degree without a sophisticated third-party solution. Centrifugo PRO protection works best in combination with protection at the infrastructure level though.
+Centrifugo PRO applies these limits with knowledge no network layer has: which command was issued, on which channel and namespace, by which user, on which connection. That is what makes it possible to allow a user their normal subscribe and publish rate while bounding the operations that cost the most.
+
+Infrastructure-level protection remains worthwhile alongside it, and the two are complementary rather than alternatives: a proxy or CDN bounds request and connection volume before it reaches the server, while Centrifugo bounds what an established, authenticated connection may do. Configure both where you can — the [recommended baseline](#recommended-baseline) below covers the Centrifugo side.
 
 ![Throttling](/img/throttling.png)
 

--- a/docs/pro/rate_limiting.md
+++ b/docs/pro/rate_limiting.md
@@ -620,21 +620,49 @@ The cost is in ingest, and only something that stops the bytes *arriving* can av
 
 ### What to do instead
 
-**Lower `websocket.message_size_limit`.** This is the first thing to check and usually the only thing needed. It is already in Centrifugo, costs nothing, and 64KB → 4KB shrinks the whole amplification 16×:
+**Bound it upstream, carefully.**
 
-```json title="config.json"
-{
-  "websocket": {
-    "message_size_limit": 4096
-  }
-}
+#### `websocket.message_size_limit` — useful, but read this first
+
+Lowering the message size limit shrinks the amplification directly. It is also the single easiest way to break your application, for two reasons that are easy to miss.
+
+**One frame carries many commands.** Centrifugo's protocol batches, and the SDKs use it: on every transport open, `centrifuge-js` puts the `connect` command *and every subscribe* into a single frame. A client subscribed to 50 channels with subscription tokens of a few hundred bytes each sends a 25KB+ frame every time it reconnects. The limit applies to that whole frame, not to individual commands.
+
+**Exceeding it closes the connection.** The limit is enforced as a transport read limit, so an oversized frame is not a refused command — the connection is dropped with a bad-request disconnect. For a client whose reconnect frame is over the limit, that is not throttling, it is a permanent outage: every reconnect attempt fails the same way.
+
+So a limit that looks fine in steady state can still make your heaviest users unable to connect at all. Size it against your **largest reconnect frame**, not against a typical publish, and leave generous headroom.
+
+#### Estimating what you actually need
+
+There is no metric for frame size — see the note below. You can estimate the important frame from the per-command metrics that do exist:
+
+```
+avg subscribe command size =
+  rate(centrifugo_transport_messages_received_size{frame_type="subscribe"}[5m])
+  / rate(centrifugo_transport_messages_received{frame_type="subscribe"}[5m])
 ```
 
-Size it against the largest message your application legitimately sends. If clients only publish small JSON, there is no reason to accept 64KB frames.
+Then, for your heaviest connections:
 
-**Shape bandwidth at the proxy** if you need a byte rate rather than a size cap. This is strictly better than doing it in Centrifugo, for two reasons: the bytes never arrive, so the ingest cost is genuinely avoided; and bandwidth shaping applies backpressure — the client's writes simply slow down, with no error and no reconnect, which is the reaction you actually want for bytes.
+```
+reconnect frame ≈ avg connect size + (channels per connection × avg subscribe size)
+```
 
-Note that not every proxy can do this. Rate limiting in nginx and Cloudflare acts on HTTP requests, and after the WebSocket upgrade the connection is an opaque byte stream to them, so their request-based rules do not apply to frames. HAProxy provides bandwidth limitation filters (`filter bwlim-in` / `bwlim-out`) that operate on the byte stream — verify the behaviour with your version and your tunnelling configuration before relying on it.
+Take the *maximum* channels per connection you support, not the average — the outlier is the connection that breaks. Then double it.
+
+:::note Observability gap
+
+Centrifugo exposes `transport_messages_received` and `transport_messages_received_size` as counters, per **command**. Dividing them gives an average command size. There is currently **no metric for frame size or for commands per frame**, which are what `message_size_limit` actually bounds — so the estimate above is the best available, and it is an estimate.
+
+A histogram of bytes per frame, and of commands per frame, would let this be sized from data instead of arithmetic. That belongs in the `centrifuge` library rather than in Centrifugo PRO, since the frame boundary is only visible inside the transport read loop.
+
+:::
+
+#### Shaping bandwidth at the proxy
+
+If you need a byte *rate* rather than a size cap, this is strictly better than doing it in Centrifugo: the bytes never arrive, so the ingest cost is genuinely avoided, and bandwidth shaping applies backpressure — the client's writes simply slow down, with no error and no disconnect. That is the reaction bytes actually want, and one Centrifugo has no way to produce.
+
+Not every proxy can do it. Rate limiting in nginx and Cloudflare acts on HTTP requests, and after the WebSocket upgrade the connection is an opaque byte stream to them, so their request-based rules never see frames. HAProxy provides bandwidth limitation filters (`filter bwlim-in` / `bwlim-out`) that operate on the byte stream — verify the behaviour with your version and your tunnelling configuration before relying on it.
 
 :::tip
 

--- a/docs/pro/rate_limiting.md
+++ b/docs/pro/rate_limiting.md
@@ -591,52 +591,54 @@ Two readings are worth alerting on:
 * Sustained hits with `dry_run="false"` mean real traffic is being rejected — either an attack, or a limit set too low.
 * Hits on `command="unsubscribe"` or `command="untrack"` mean a connection is behaving abnormally, since those commands are never actually rejected.
 
-## Limiting bytes, not just commands
+## Large payloads: bound them before Centrifugo
 
 Command buckets count frames. The transport bounds bytes per frame. Their product is the real limit, and it is wide: at the default 64KB `websocket.message_size_limit`, a connection allowed 100 commands/s may push over 6 MB/s **without breaking a single rule**.
 
-Measured — four connections at 90 frames/s each, inside a 100/s budget, zero rejections:
+Measured — four connections at 90 frames/s each, inside a 100/s budget:
 
 | | small frames | 60KB frames |
 |---|---:|---:|
-| frames delivered/s | 346 | 341 |
-| bytes/s ingested | 20.8k | **20.95M** |
-| rate limit rejections | 0 | **0** |
-| server CPU | 60ms | 230ms |
+| frames delivered/s | 353 | 351 |
+| bytes/s ingested | 21.2k | **21.59M** |
+| rate limit rejections | **0** | **0** |
+| server CPU | 70ms | **330ms** |
 
-A `bytes` bucket meters incoming command bytes instead, with `rate` read as bytes per interval:
+Same frame rate, same limits, zero rejections, 1024× the bytes and 4.4× the CPU.
+
+**The fix for this is not another limit inside Centrifugo.** A byte budget was built and measured, and it does not pay for itself:
+
+| reaction | admitted bytes/s | server CPU |
+|---|---:|---:|
+| no byte budget | 21.0M | 230ms |
+| refuse over budget | 10.6M | **360ms** |
+| disconnect over budget | 10.6M | **520ms** |
+
+A frame's size is only known once it has been read and decoded, so refusing it saves nothing on the way in — it adds an error reply on top of work already done. Disconnecting is worse again: a client only a few times over its budget is cut off constantly, and the reconnect churn costs more than the frames did.
+
+The cost is in ingest, and only something that stops the bytes *arriving* can avoid it. That is upstream of Centrifugo.
+
+### What to do instead
+
+**Lower `websocket.message_size_limit`.** This is the first thing to check and usually the only thing needed. It is already in Centrifugo, costs nothing, and 64KB → 4KB shrinks the whole amplification 16×:
 
 ```json title="config.json"
 {
-  "client": {
-    "rate_limit": {
-      "client_command": {
-        "enabled": true,
-        "total": {"enabled": true, "buckets": [{"interval": "1s", "rate": 100}]},
-        "bytes": {"enabled": true, "buckets": [{"interval": "1s", "rate": 1048576}]}
-      }
-    }
+  "websocket": {
+    "message_size_limit": 4096
   }
 }
 ```
 
-Set the rate to at least `message_size_limit`, or a single largest-allowed frame drains the whole bucket. Over-limit frames are refused with `ErrorTooManyRequests`, except `unsubscribe` and `untrack`, which are never refused for the reasons above — their bytes are still charged, so they spend the budget the commands around them need.
+Size it against the largest message your application legitimately sends. If clients only publish small JSON, there is no reason to accept 64KB frames.
 
-:::caution What this does and does not protect
+**Shape bandwidth at the proxy** if you need a byte rate rather than a size cap. This is strictly better than doing it in Centrifugo, for two reasons: the bytes never arrive, so the ingest cost is genuinely avoided; and bandwidth shaping applies backpressure — the client's writes simply slow down, with no error and no reconnect, which is the reaction you actually want for bytes.
 
-**It bounds what large payloads cost downstream — the broker, and any backend fanout. It does not reduce the cost of receiving them.**
+Note that not every proxy can do this. Rate limiting in nginx and Cloudflare acts on HTTP requests, and after the WebSocket upgrade the connection is an opaque byte stream to them, so their request-based rules do not apply to frames. HAProxy provides bandwidth limitation filters (`filter bwlim-in` / `bwlim-out`) that operate on the byte stream — verify the behaviour with your version and your tunnelling configuration before relying on it.
 
-A frame's size is only known once it has been read and decoded, so refusing it saves nothing on the way in. Measured against the same workload:
+:::tip
 
-| reaction | admitted bytes/s | server CPU |
-|---|---:|---:|
-| no byte budget | 20.95M | 230ms |
-| refuse over budget | **10.58M** | 360ms |
-| disconnect over budget | 10.58M | 520ms |
-
-59% less reaches the broker, and ingest costs somewhat more rather than less. Disconnecting instead is worse again: a client only a few times over its budget is cut off constantly, and the reconnect churn costs more than the frames did.
-
-This limit is therefore in the same category as the command buckets — it protects what is behind Centrifugo, not Centrifugo itself. For the node's own CPU, the layers that matter are [`client_error`](#disconnecting-abusive-or-misbehaving-connections) and [`ip_connect`](#per-ip-connect-rate-limit).
+Rate limits inside Centrifugo are best at what only Centrifugo knows: which command it is, which channel and namespace, which user, and which connection. Bytes on the wire are not in that category, and are better handled by the layer that owns the wire.
 
 :::
 

--- a/docs/pro/rate_limiting.md
+++ b/docs/pro/rate_limiting.md
@@ -75,6 +75,12 @@ From this baseline you can tighten specific commands by adding explicit buckets 
 
 ## Recommended baseline
 
+:::info Version
+
+`dry_run`, `ip_connect` (with `max_concurrent_per_ip`) and `disconnect_on_accounted_limit` are available since Centrifugo v6.9.5. The `centrifugo_transport_frame_size` metric referenced below is available since v6.9.4.
+
+:::
+
 Command limits govern how much work a connection may ask the server to do. Two further layers govern the connections themselves, and the three are designed to be used together:
 
 ```json title="config.json"
@@ -593,7 +599,7 @@ Size the limit against your **largest reconnect frame**, not a typical publish, 
 
 ### Choosing a value
 
-`centrifugo_transport_frame_size` (available since Centrifugo v6.9.0) is a histogram of received frame sizes. Set the limit from an observed high quantile:
+`centrifugo_transport_frame_size` (available since Centrifugo v6.9.4) is a histogram of received frame sizes. Set the limit from an observed high quantile:
 
 ```
 histogram_quantile(0.99, sum(rate(centrifugo_transport_frame_size_bucket[5m])) by (le, transport))

--- a/docs/pro/rate_limiting.md
+++ b/docs/pro/rate_limiting.md
@@ -71,9 +71,43 @@ Add a `total` bucket alongside `default` if you want a hard cap on the combined 
 
 From this baseline you can tighten specific commands by adding explicit buckets — for example, lowering `publish` or `history` limits — without touching the rest. The sections below describe the full per-command configuration.
 
+## Recommended baseline
+
+Command limits govern how much work a connection may ask the server to do. Two further layers govern the connections themselves, and the three are designed to be used together:
+
+```json title="config.json"
+{
+  "client": {
+    "rate_limit": {
+      "client_command": {
+        "enabled": true,
+        "total": {"enabled": true, "buckets": [{"interval": "1s", "rate": 100}]},
+        "default": {"enabled": true, "buckets": [{"interval": "1s", "rate": 100}]},
+        "disconnect_on_accounted_limit": true
+      },
+      "client_error": {
+        "enabled": true,
+        "total": {"enabled": true, "buckets": [{"interval": "5s", "rate": 20}]}
+      },
+      "ip_connect": {
+        "enabled": true,
+        "buckets": [{"interval": "1s", "rate": 10}],
+        "max_concurrent_per_ip": 20
+      }
+    }
+  }
+}
+```
+
+* [`client_command`](#in-memory-per-connection-rate-limit) bounds the operations a connection may perform.
+* [`client_error`](#disconnecting-abusive-or-misbehaving-connections) closes a connection that keeps producing protocol errors, so a misbehaving client stops consuming resources rather than being refused one command at a time.
+* [`ip_connect`](#per-ip-connect-rate-limit) bounds connection attempts and concurrent connections per address, which is what applies before a connection is authenticated.
+
+Each is described in detail below. Start with [dry run](#try-limits-before-enforcing-them) to size the numbers against your own traffic before enforcing them.
+
 ## Try limits before enforcing them
 
-The hardest part of rate limiting is picking numbers. Set them too low and you break normal users; set them too high and they protect nothing. Guessing is avoidable — every layer supports `dry_run`:
+Choosing values is the hardest part of rate limiting: too low and normal users are affected, too high and the limits do little. Every layer supports `dry_run`, so the numbers can be measured against your own traffic first:
 
 ```json title="config.json"
 {
@@ -402,24 +436,18 @@ Use `user_command` as a cheap front-end filter for `redis_user_command`. Because
 
 ## Commands that are counted but never rejected
 
-`unsubscribe` and `untrack` are treated differently from every other command: their buckets are charged and reported, but exceeding them **never rejects the command**.
+`unsubscribe` and `untrack` are treated differently from other commands: their buckets are charged and reported, but exceeding them does not refuse the command.
 
-This is deliberate, and it is about load rather than leniency. Both commands exist for a client to shed state it no longer wants — leaving a channel, dropping a tracked key — so server-side work goes *down* when they succeed. Refusing them inverts that:
+This is deliberate. Both commands exist for a client to release state it no longer needs — leaving a channel, dropping a tracked key — so completing them reduces server-side work. Refusing them does not:
 
-* Every Centrifugo SDK treats an error reply to `unsubscribe` as fatal and reconnects. So rejecting one cheap command produces a full reconnect instead: a new transport, a connect handshake, token verification, a connect proxy call if configured, and a resubscribe to every channel. Under load that turns a rate limit into a reconnect storm.
-* A rejected `untrack` leaves the server tracking a key the client has already forgotten, so it keeps broadcasting updates nobody wants. Load goes up and the two sides disagree permanently.
+* Centrifugo SDKs treat an error reply to `unsubscribe` as fatal and reconnect. Refusing one inexpensive command therefore produces a full reconnect instead: a new transport, a connect handshake, token verification, a connect proxy call if configured, and a resubscribe to every channel.
+* A refused `untrack` leaves the server tracking a key the client has already released, so it keeps broadcasting updates that are no longer wanted.
 
-Protection is not lost, because these commands still consume tokens — including from `total`, and unlike enforced commands they consume it even when their own bucket is empty. A flood of unsubscribes therefore drains the connection's overall budget, and the commands that *do* ask the server to do work (`publish`, `history`, `presence`, `rpc`, `subscribe`) start being rejected instead. Rejection still happens; it happens where an SDK handles it sanely.
+Their buckets remain fully effective. These commands consume tokens like any other — including from `total`, and unlike enforced commands they consume it even when their own bucket is empty. A connection issuing them at a high rate therefore draws down its overall budget, and the commands that ask the server to perform work are limited accordingly.
 
-That covers an attacker who wants to do something else. It does **not** cover one that sends nothing but `unsubscribe` — see below.
+### Disconnecting a client that exceeds them
 
-### Disconnecting a client that floods them
-
-Charging `total` protects the commands an attacker is *not* sending. It does nothing about a client that sends nothing but `unsubscribe`: that command is always allowed, always succeeds, and produces no error for the error limit to count, so no other layer sees it either.
-
-Measured against a real server at 1M unsubscribe frames/s offered, with every other limit enabled: **0.1% of the flood was stopped**, server CPU was unchanged, and legitimate users' p99 round trip was **377ms**. The same load as `publish` was 99.8% stopped.
-
-`disconnect_on_accounted_limit` closes a connection that keeps exceeding these buckets:
+For clients that persistently exceed these buckets, `disconnect_on_accounted_limit` closes the connection:
 
 ```json title="config.json"
 {
@@ -442,53 +470,21 @@ Measured against a real server at 1M unsubscribe frames/s offered, with every ot
 }
 ```
 
-With it, the same flood is 99.8% stopped, server CPU drops from 5.8s to 530ms, and legitimate p99 returns to **744µs**.
+Disconnecting is not the same as refusing a command. The disconnect code is in the range that instructs SDKs not to reconnect, so the connection is released rather than re-established.
 
-Disconnecting is not the same as refusing. The disconnect code is in the range that tells SDKs not to reconnect, so it sheds the load rather than converting it into a reconnect — which is exactly what refusing the command did.
+:::tip Configure `ip_connect` alongside it
 
-It is off by default, and worth sizing carefully: a client doing legitimate rapid channel churn must not be cut off by a bucket set too tight. Run with `dry_run: true` first and watch the metric before enabling it. The decision is made per connection — the per-user layer never disconnects, since one abusive session must not take down a user's other sessions.
-
-:::caution Requires a connect rate limit
-
-**Disconnecting only works if something meters how fast the client is allowed back.** An attacker does not use an SDK, so it ignores the advice not to reconnect — and every reconnect gives it a new client ID and therefore a fresh set of per-connection buckets.
-
-Measured at 1M unsubscribe frames/s from a client that always reconnects:
-
-| | no limits | disconnect only | disconnect + `ip_connect` |
-|---|---:|---:|---:|
-| frames delivered/s | 499.4k | 420.1k | **1.1k** |
-| reconnects won | 8 | 1547 | 14 |
-| server CPU | 5.46s | 5.31s | **710ms** |
-| legitimate p99 | 359ms | 10.07ms | **707µs** |
-| flood stopped | — | **15.9%** | **99.8%** |
-
-Enable [`ip_connect`](#per-ip-connect-rate-limit) alongside it, or enforce a per-IP connection rate in your infrastructure. Centrifugo logs a warning at startup if `disconnect_on_accounted_limit` is set without `ip_connect` configured.
+Closing a connection is effective when combined with a limit on how quickly a client may open a new one. Enable [`ip_connect`](#per-ip-connect-rate-limit) together with this option, or apply a per-IP connection rate limit in your infrastructure. Centrifugo logs a warning at startup if `disconnect_on_accounted_limit` is set without `ip_connect` configured.
 
 :::
 
-Their buckets are also useful as a pure **detection** signal. Configure `unsubscribe` at a rate no real client should reach and alert on the metric:
+The option is off by default and worth sizing carefully: a client legitimately switching channels quickly should not be disconnected by a bucket set too tight. Run with `dry_run: true` first and watch the metric before enabling it. The decision is made per connection — the per-user layer never disconnects, so one session cannot affect a user's other sessions.
 
-```json title="config.json"
-{
-  "client": {
-    "rate_limit": {
-      "client_command": {
-        "enabled": true,
-        "unsubscribe": {
-          "enabled": true,
-          "buckets": [{"interval": "1s", "rate": 50}]
-        }
-      }
-    }
-  }
-}
-```
-
-Over-limit hits show up as `centrifugo_rate_limit_client_over_limit_count{command="unsubscribe"}` and mean "this connection is behaving abnormally", not "this command was refused".
+These buckets are also a useful signal on their own. Configured at a rate no normal client reaches, over-limit hits appear as `centrifugo_rate_limit_client_over_limit_count{command="unsubscribe"}` and indicate a connection behaving abnormally rather than a command being refused.
 
 :::note
 
-For the same reason, `unsubscribe` and `untrack` are not evaluated by the `redis_user_command` layer. That layer has no `total` bucket to accumulate into and never rejects these commands, so a Redis round trip per unsubscribe would buy nothing. They are charged by the two in-memory layers.
+For the same reason, `unsubscribe` and `untrack` are not evaluated by the `redis_user_command` layer. That layer has no `total` bucket and does not refuse these commands, so a Redis round trip for them would add latency without changing any outcome. They are charged by the two in-memory layers.
 
 :::
 
@@ -496,8 +492,8 @@ For the same reason, `unsubscribe` and `untrack` are not evaluated by the `redis
 
 Every layer above keys on a client ID or a user ID, which means none of them can act until a connection exists and — for the per-user layers — until it has authenticated. Two things fall outside that:
 
-* **Anonymous connections.** With `client.allow_anonymous` there is no user ID, so `user_command` and `redis_user_command` skip these connections entirely. `client_command` does apply, but it only sets the cost *per connection* — and the number of connections is the attacker's choice.
-* **Connect-time work.** A connect attempt verifies a JWT and, when the connect proxy is configured, makes an HTTP call to your backend. Both happen before there is any user ID to rate limit on, so a flood of unauthenticated connects reaches your backend at full rate.
+* **Anonymous connections.** With `client.allow_anonymous` there is no user ID, so `user_command` and `redis_user_command` have no key to aggregate on. `client_command` applies per connection, and `ip_connect` bounds how many connections an address may open and hold — which is what makes the per-connection budget meaningful in aggregate.
+* **Connect-time work.** A connect attempt verifies a JWT and, when the connect proxy is configured, makes an HTTP call to your backend. Both happen before there is any user ID to rate limit on, so `ip_connect` is what bounds how often an address can trigger them.
 
 `ip_connect` closes both. It runs in HTTP middleware, before the connection handler, keyed on the client's address:
 
@@ -525,23 +521,11 @@ Options:
 * `buckets` – token buckets, same format as everywhere else. All listed buckets must allow the attempt.
 * `dry_run` – evaluate and report without rejecting. Strongly recommended for the first rollout: this layer sits in front of every connection, so a number that is too low locks users out.
 * `max_concurrent_per_ip` – how many connections one address may hold open at once. Zero (default) means no limit. **This is a different limit from the buckets above**, and both are needed — see below.
-* `max_tracked_ips` – how many addresses are tracked at once, default `100000`. Once reached, addresses that are not already tracked are **allowed through** rather than evicting live entries. Failing open is deliberate: rejecting unknown addresses at capacity would let an attacker fill the table with junk and deny service to everybody else.
+* `max_tracked_ips` – how many addresses are tracked at once, default `100000`. Once reached, addresses that are not already tracked are **allowed through** rather than evicting live entries. Failing open is deliberate: refusing untracked addresses at capacity could deny service to legitimate clients, so the cap bounds memory rather than admission.
 
-### Rate is not enough: cap concurrent connections too
+### Cap concurrent connections as well as their rate
 
-The buckets above bound how *fast* an address acquires connections. They do not bound how many it *holds*.
-
-Per-connection rate limits are per connection. An attacker that acquires slowly enough to stay under the rate limit and simply keeps the connections open multiplies its allowed command budget by the number it holds — without ever breaking a rule. Measured, acquiring at 4/s against a 5/s connect limit:
-
-| | no per-IP layer | rate + `max_concurrent_per_ip: 4` |
-|---|---:|---:|
-| connections held | 12 | **4** |
-| connect attempts refused | 0 | 12 |
-| effective command budget | **7.4×** the per-connection limit | **1.5×** |
-| server CPU | 5.74s | **140ms** |
-| legitimate p99 | 4.17ms | **406µs** |
-
-Scaled up, this is also how a single address exhausts `client.connection_limit` and denies service to everybody else. Set both:
+The `buckets` above govern how quickly an address may open connections. `max_concurrent_per_ip` governs how many it may hold at once:
 
 ```json title="config.json"
 {
@@ -557,17 +541,19 @@ Scaled up, this is also how a single address exhausts `client.connection_limit` 
 }
 ```
 
-Size `max_concurrent_per_ip` against your own users, not against attackers: several browser tabs, a mobile app reconnecting while the old socket is still closing, and users sharing an office NAT all legitimately hold more than one connection. If you terminate at a proxy that does not forward the client address, every user appears as one address and this limit is not usable — leave it at zero.
+Both matter, because per-connection rate limits apply per connection: the budget available to an address is its per-connection budget multiplied by the number of connections it holds. A connection rate limit alone does not bound that number, and neither does `client.connection_limit`, which is a node-wide cap rather than a per-address one.
+
+Size `max_concurrent_per_ip` against your own users rather than against a worst case: several browser tabs, a mobile app reconnecting while the previous socket is still closing, and users sharing an office NAT all legitimately hold more than one connection. If you terminate at a proxy that does not forward the client address, every user appears as a single address and this limit is not usable — leave it at zero.
 
 :::note
 
-Address derivation follows the same rules Centrifugo uses elsewhere: `X-Forwarded-For` and `X-Real-IP` are trusted **only** when the immediate socket peer is a loopback or private address, i.e. a local reverse proxy or load balancer. For a directly connected public client those headers are attacker-controlled and ignored, so a client cannot spoof them to evade its own limit or exhaust somebody else's bucket. If you terminate TLS on a public-IP load balancer that does not appear as a private peer, put a private-address proxy in front or rely on infrastructure-level limits instead.
+Address derivation follows the same rules Centrifugo uses elsewhere: `X-Forwarded-For` and `X-Real-IP` are trusted **only** when the immediate socket peer is a loopback or private address, i.e. a local reverse proxy or load balancer. For a directly connected public client those headers are client-supplied and are ignored, so a client cannot present them to select a different bucket than its own. If you terminate TLS on a public-IP load balancer that does not appear as a private peer, put a private-address proxy in front or rely on infrastructure-level limits instead.
 
 :::
 
 :::tip
 
-`ip_connect` complements the existing `client.connection_rate_limit`, which caps new connections per node *in aggregate*. An aggregate cap protects the node but treats all callers alike, so one flooding source can consume the whole budget and starve everyone else. A per-IP limit charges the source that is actually responsible. Using both is reasonable: per-IP for fairness, aggregate as a backstop.
+`ip_connect` complements the existing `client.connection_rate_limit`, which caps new connections per node *in aggregate*. An aggregate cap treats all callers alike, so a single busy source can consume the whole budget. A per-IP limit accounts for each address separately. Using both is reasonable: per-IP for fairness between clients, aggregate as a node-level backstop.
 
 :::
 
@@ -588,89 +574,39 @@ The counter is incremented **only** when a bucket denies. Commands that pass the
 
 Two readings are worth alerting on:
 
-* Sustained hits with `dry_run="false"` mean real traffic is being rejected — either an attack, or a limit set too low.
-* Hits on `command="unsubscribe"` or `command="untrack"` mean a connection is behaving abnormally, since those commands are never actually rejected.
+* Sustained hits with `dry_run="false"` mean traffic is being refused. Check whether the limit matches what your application legitimately does before assuming it is unwanted traffic.
+* Hits on `command="unsubscribe"` or `command="untrack"` indicate a connection issuing these at an unusual rate. Since these commands are always completed, this is a behavioural signal rather than a record of refused work.
 
-## Large payloads: bound them before Centrifugo
+## Message size and large payloads
 
-Command buckets count frames. The transport bounds bytes per frame. Their product is the real limit, and it is wide: at the default 64KB `websocket.message_size_limit`, a connection allowed 100 commands/s may push over 6 MB/s **without breaking a single rule**.
+Command buckets count operations. The size of each command is bounded separately, by `websocket.message_size_limit` and its equivalents on other transports. The two work together: the command rate sets how many operations a connection may perform, and the size limit sets how large each may be.
 
-Measured — four connections at 90 frames/s each, inside a 100/s budget:
+If your application sends small messages, lowering the size limit is a straightforward way to reduce the volume a single connection can transfer. It needs care, though, for two reasons.
 
-| | small frames | 60KB frames |
-|---|---:|---:|
-| frames delivered/s | 353 | 351 |
-| bytes/s ingested | 21.2k | **21.59M** |
-| rate limit rejections | **0** | **0** |
-| server CPU | 70ms | **330ms** |
+**The limit applies to a whole frame.** Centrifugo's protocol supports batching, and the SDKs use it: on every transport open, `centrifuge-js` sends the `connect` command and every subscribe in a single frame. A client subscribed to many channels with subscription tokens therefore sends a large frame each time it connects. `message_size_limit` is applied as a transport read limit, so it bounds that whole frame — while the protocol decoder additionally bounds each individual command.
 
-Same frame rate, same limits, zero rejections, 1024× the bytes and 4.4× the CPU.
+**A frame over the limit ends the connection.** It is not a refused command: the connection is closed with WebSocket code 1009, which SDKs report as a message size limit error and do not retry. A client whose reconnect frame exceeds the limit is therefore unable to connect at all, and because frame size grows with subscription count, this affects the users on the most channels first.
 
-**The fix for this is not another limit inside Centrifugo.** A byte budget was built and measured, and it does not pay for itself:
+Size the limit against your **largest reconnect frame**, not a typical publish, and leave headroom.
 
-| reaction | admitted bytes/s | server CPU |
-|---|---:|---:|
-| no byte budget | 21.0M | 230ms |
-| refuse over budget | 10.6M | **360ms** |
-| disconnect over budget | 10.6M | **520ms** |
+### Choosing a value
 
-A frame's size is only known once it has been read and decoded, so refusing it saves nothing on the way in — it adds an error reply on top of work already done. Disconnecting is worse again: a client only a few times over its budget is cut off constantly, and the reconnect churn costs more than the frames did.
-
-The cost is in ingest, and only something that stops the bytes *arriving* can avoid it. That is upstream of Centrifugo.
-
-### What to do instead
-
-**Bound it upstream, carefully.**
-
-#### `websocket.message_size_limit` — useful, but read this first
-
-Lowering the message size limit shrinks the amplification directly. It is also the single easiest way to break your application, for two reasons that are easy to miss.
-
-**One frame carries many commands.** Centrifugo's protocol batches, and the SDKs use it: on every transport open, `centrifuge-js` puts the `connect` command *and every subscribe* into a single frame. A client subscribed to 50 channels with subscription tokens of a few hundred bytes each sends a 25KB+ frame every time it reconnects.
-
-`message_size_limit` does double duty here. It bounds each individual **command** (the decoder rejects anything larger), and on WebSocket it also bounds the whole **frame** — it is applied as the transport read limit. The frame bound is the one that bites, because it is the one the batch has to fit inside. WebTransport has no frame bound, only the per-command one, so batching does not have the same cliff there.
-
-**Exceeding it closes the connection.** The limit is enforced as a transport read limit, so an oversized frame is not a refused command — the connection is dropped with a bad-request disconnect. For a client whose reconnect frame is over the limit, that is not throttling, it is a permanent outage: every reconnect attempt fails the same way.
-
-So a limit that looks fine in steady state can still make your heaviest users unable to connect at all. Size it against your **largest reconnect frame**, not against a typical publish, and leave generous headroom.
-
-#### Estimating what you actually need
-
-There is no metric for frame size — see the note below. You can estimate the important frame from the per-command metrics that do exist:
+`centrifugo_transport_frame_size` (available since Centrifugo v6.9.0) is a histogram of received frame sizes. Set the limit from an observed high quantile:
 
 ```
-avg subscribe command size =
-  rate(centrifugo_transport_messages_received_size{frame_type="subscribe"}[5m])
-  / rate(centrifugo_transport_messages_received{frame_type="subscribe"}[5m])
+histogram_quantile(0.99, sum(rate(centrifugo_transport_frame_size_bucket[5m])) by (le, transport))
 ```
 
-Then, for your heaviest connections:
+Two companion signals are useful alongside it:
 
-```
-reconnect frame ≈ avg connect size + (channels per connection × avg subscribe size)
-```
+* `centrifugo_transport_outgoing_close_count{code="1009"}` counts connections closed because a frame exceeded the limit — a non-zero rate means the limit is set below what some clients send.
+* Dividing `centrifugo_transport_messages_received` by `centrifugo_transport_frame_size_count` gives the mean number of commands per frame, i.e. how much your clients batch.
 
-Take the *maximum* channels per connection you support, not the average — the outlier is the connection that breaks. Then double it.
+### Bandwidth shaping
 
-:::note Observability gap
+If you need to limit throughput as a byte rate rather than a per-message size, this is best applied at the proxy in front of Centrifugo. Bandwidth shaping there applies backpressure — a client's writes slow down, without an error or a disconnect — and the traffic is bounded before it reaches the server.
 
-Centrifugo exposes `transport_messages_received` and `transport_messages_received_size` as counters, per **command**. Dividing them gives an average command size. There is currently **no metric for frame size or for commands per frame**, which are what `message_size_limit` actually bounds — so the estimate above is the best available, and it is an estimate.
-
-A histogram of bytes per frame, and of commands per frame, would let this be sized from data instead of arithmetic. That belongs in the `centrifuge` library rather than in Centrifugo PRO, since the frame boundary is only visible inside the transport read loop.
-
-:::
-
-#### Shaping bandwidth at the proxy
-
-If you need a byte *rate* rather than a size cap, this is strictly better than doing it in Centrifugo: the bytes never arrive, so the ingest cost is genuinely avoided, and bandwidth shaping applies backpressure — the client's writes simply slow down, with no error and no disconnect. That is the reaction bytes actually want, and one Centrifugo has no way to produce.
-
-Not every proxy can do it. Rate limiting in nginx and Cloudflare acts on HTTP requests, and after the WebSocket upgrade the connection is an opaque byte stream to them, so their request-based rules never see frames. HAProxy provides bandwidth limitation filters (`filter bwlim-in` / `bwlim-out`) that operate on the byte stream — verify the behaviour with your version and your tunnelling configuration before relying on it.
-
-:::tip
-
-Rate limits inside Centrifugo are best at what only Centrifugo knows: which command it is, which channel and namespace, which user, and which connection. Bytes on the wire are not in that category, and are better handled by the layer that owns the wire.
-
-:::
+Note that not every proxy can do this for WebSocket. Rate limiting in nginx and Cloudflare acts on HTTP requests, and after the WebSocket upgrade the connection is an opaque byte stream to them, so their request-based rules do not apply to individual frames. HAProxy provides bandwidth limitation filters (`filter bwlim-in` / `bwlim-out`) that operate on the byte stream — verify the behaviour with your version and tunnelling configuration.
 
 ## Channel namespace overrides
 
@@ -806,11 +742,11 @@ If a client will have more than 20 protocol errors per 5 second – it will be d
 
 Three behaviours changed in the rate limit subsystem. All of them are safe by default — no new limit starts enforcing on upgrade — but two are worth checking if you already have limits configured.
 
-**`unsubscribe` and `untrack` are no longer rejected.** Previously an over-limit `unsubscribe` returned an error, which every SDK turns into a full reconnect. They are now charged and reported but always allowed. If you relied on the rejection, nothing replaces it directly — alert on the metric instead, and let the `total` bucket absorb floods. This strictly reduces rejections, so it cannot break a working deployment.
+**`unsubscribe` and `untrack` are no longer refused.** Previously an over-limit `unsubscribe` returned an error, which SDKs treat as fatal and follow with a reconnect. They are now charged and reported but always completed — see [Commands that are counted but never rejected](#commands-that-are-counted-but-never-rejected). Their buckets still limit the connection through `total`, and [`disconnect_on_accounted_limit`](#disconnecting-a-client-that-exceeds-them) is available where a firmer response is wanted. This change only reduces the number of refused commands, so it cannot break a working deployment.
 
-**`unsubscribe` and `untrack` now work on the `user_command` layer.** They were documented and accepted as configuration but registered no buckets there, so setting them — or relying on `default` to cover them — silently did nothing. They now behave as documented. The practical consequence is that these commands consume the per-user `total` bucket where they previously consumed nothing. If your `user_command.total` is tight and your application swaps channels frequently, check the metric before and after upgrading, or run the layer with `dry_run: true` for a period first.
+**`unsubscribe` and `untrack` are now applied on the `user_command` layer.** Configuring them there — or relying on `default` to cover them — now takes effect as documented. The practical consequence is that these commands consume the per-user `total` bucket where they previously did not. If your `user_command.total` is tight and your application switches channels frequently, run the layer with `dry_run: true` for a period and check the metric before enforcing.
 
-**Server-initiated refreshes are no longer rate limited.** `refresh` and `sub_refresh` limits previously applied to Centrifugo's own subscription and connection expiry refreshes as well as to client-sent commands. Exhausting those buckets could therefore drop subscriptions or disconnect connections that had sent nothing. Only client-initiated refreshes are limited now. If you had raised these limits to work around unexplained disconnects, you can lower them again.
+**Refresh limits now apply only to client-sent commands.** `refresh` and `sub_refresh` buckets previously also counted Centrifugo's own subscription and connection expiry refreshes. They now count only refreshes a client asked for, so these buckets can be sized against client behaviour alone. If you had raised them to leave room for server-initiated refreshes, they can be lowered again.
 
 Nothing in the configuration format changed incompatibly: `dry_run` defaults to `false` on every layer, and `ip_connect` is disabled unless configured.
 

--- a/docs/pro/rate_limiting.md
+++ b/docs/pro/rate_limiting.md
@@ -411,7 +411,44 @@ This is deliberate, and it is about load rather than leniency. Both commands exi
 
 Protection is not lost, because these commands still consume tokens — including from `total`, and unlike enforced commands they consume it even when their own bucket is empty. A flood of unsubscribes therefore drains the connection's overall budget, and the commands that *do* ask the server to do work (`publish`, `history`, `presence`, `rpc`, `subscribe`) start being rejected instead. Rejection still happens; it happens where an SDK handles it sanely.
 
-Their buckets remain useful as a **detection** signal. Configure `unsubscribe` at a rate no real client should reach and alert on the metric:
+That covers an attacker who wants to do something else. It does **not** cover one that sends nothing but `unsubscribe` — see below.
+
+### Disconnecting a client that floods them
+
+Charging `total` protects the commands an attacker is *not* sending. It does nothing about a client that sends nothing but `unsubscribe`: that command is always allowed, always succeeds, and produces no error for the error limit to count, so no other layer sees it either.
+
+Measured against a real server at 1M unsubscribe frames/s offered, with every other limit enabled: **0.1% of the flood was stopped**, server CPU was unchanged, and legitimate users' p99 round trip was **377ms**. The same load as `publish` was 99.8% stopped.
+
+`disconnect_on_accounted_limit` closes a connection that keeps exceeding these buckets:
+
+```json title="config.json"
+{
+  "client": {
+    "rate_limit": {
+      "client_command": {
+        "enabled": true,
+        "disconnect_on_accounted_limit": true,
+        "unsubscribe": {
+          "enabled": true,
+          "buckets": [{"interval": "1s", "rate": 50}]
+        },
+        "untrack": {
+          "enabled": true,
+          "buckets": [{"interval": "1s", "rate": 50}]
+        }
+      }
+    }
+  }
+}
+```
+
+With it, the same flood is 99.8% stopped, server CPU drops from 5.8s to 530ms, and legitimate p99 returns to **744µs**.
+
+Disconnecting is not the same as refusing. The disconnect code is in the range that tells SDKs not to reconnect, so it sheds the load rather than converting it into a reconnect — which is exactly what refusing the command did.
+
+It is off by default, and worth sizing carefully: a client doing legitimate rapid channel churn must not be cut off by a bucket set too tight. Run with `dry_run: true` first and watch the metric before enabling it. The decision is made per connection — the per-user layer never disconnects, since one abusive session must not take down a user's other sessions.
+
+Their buckets are also useful as a pure **detection** signal. Configure `unsubscribe` at a rate no real client should reach and alert on the metric:
 
 ```json title="config.json"
 {

--- a/docs/pro/rate_limiting.md
+++ b/docs/pro/rate_limiting.md
@@ -626,7 +626,9 @@ The cost is in ingest, and only something that stops the bytes *arriving* can av
 
 Lowering the message size limit shrinks the amplification directly. It is also the single easiest way to break your application, for two reasons that are easy to miss.
 
-**One frame carries many commands.** Centrifugo's protocol batches, and the SDKs use it: on every transport open, `centrifuge-js` puts the `connect` command *and every subscribe* into a single frame. A client subscribed to 50 channels with subscription tokens of a few hundred bytes each sends a 25KB+ frame every time it reconnects. The limit applies to that whole frame, not to individual commands.
+**One frame carries many commands.** Centrifugo's protocol batches, and the SDKs use it: on every transport open, `centrifuge-js` puts the `connect` command *and every subscribe* into a single frame. A client subscribed to 50 channels with subscription tokens of a few hundred bytes each sends a 25KB+ frame every time it reconnects.
+
+`message_size_limit` does double duty here. It bounds each individual **command** (the decoder rejects anything larger), and on WebSocket it also bounds the whole **frame** — it is applied as the transport read limit. The frame bound is the one that bites, because it is the one the batch has to fit inside. WebTransport has no frame bound, only the per-command one, so batching does not have the same cliff there.
 
 **Exceeding it closes the connection.** The limit is enforced as a transport read limit, so an oversized frame is not a refused command — the connection is dropped with a bad-request disconnect. For a client whose reconnect frame is over the limit, that is not throttling, it is a permanent outage: every reconnect attempt fails the same way.
 

--- a/docs/pro/rate_limiting.md
+++ b/docs/pro/rate_limiting.md
@@ -591,6 +591,55 @@ Two readings are worth alerting on:
 * Sustained hits with `dry_run="false"` mean real traffic is being rejected — either an attack, or a limit set too low.
 * Hits on `command="unsubscribe"` or `command="untrack"` mean a connection is behaving abnormally, since those commands are never actually rejected.
 
+## Limiting bytes, not just commands
+
+Command buckets count frames. The transport bounds bytes per frame. Their product is the real limit, and it is wide: at the default 64KB `websocket.message_size_limit`, a connection allowed 100 commands/s may push over 6 MB/s **without breaking a single rule**.
+
+Measured — four connections at 90 frames/s each, inside a 100/s budget, zero rejections:
+
+| | small frames | 60KB frames |
+|---|---:|---:|
+| frames delivered/s | 346 | 341 |
+| bytes/s ingested | 20.8k | **20.95M** |
+| rate limit rejections | 0 | **0** |
+| server CPU | 60ms | 230ms |
+
+A `bytes` bucket meters incoming command bytes instead, with `rate` read as bytes per interval:
+
+```json title="config.json"
+{
+  "client": {
+    "rate_limit": {
+      "client_command": {
+        "enabled": true,
+        "total": {"enabled": true, "buckets": [{"interval": "1s", "rate": 100}]},
+        "bytes": {"enabled": true, "buckets": [{"interval": "1s", "rate": 1048576}]}
+      }
+    }
+  }
+}
+```
+
+Set the rate to at least `message_size_limit`, or a single largest-allowed frame drains the whole bucket. Over-limit frames are refused with `ErrorTooManyRequests`, except `unsubscribe` and `untrack`, which are never refused for the reasons above — their bytes are still charged, so they spend the budget the commands around them need.
+
+:::caution What this does and does not protect
+
+**It bounds what large payloads cost downstream — the broker, and any backend fanout. It does not reduce the cost of receiving them.**
+
+A frame's size is only known once it has been read and decoded, so refusing it saves nothing on the way in. Measured against the same workload:
+
+| reaction | admitted bytes/s | server CPU |
+|---|---:|---:|
+| no byte budget | 20.95M | 230ms |
+| refuse over budget | **10.58M** | 360ms |
+| disconnect over budget | 10.58M | 520ms |
+
+59% less reaches the broker, and ingest costs somewhat more rather than less. Disconnecting instead is worse again: a client only a few times over its budget is cut off constantly, and the reconnect churn costs more than the frames did.
+
+This limit is therefore in the same category as the command buckets — it protects what is behind Centrifugo, not Centrifugo itself. For the node's own CPU, the layers that matter are [`client_error`](#disconnecting-abusive-or-misbehaving-connections) and [`ip_connect`](#per-ip-connect-rate-limit).
+
+:::
+
 ## Channel namespace overrides
 
 Centrifugo PRO allows defining rate limit overrides on a per-namespace basis for channel operations. A namespace override **completely replaces** the base command bucket for channels in that namespace — the base bucket is not checked alongside the override, only the override buckets are used. This means overrides can both relax and tighten limits relative to the base.

--- a/docs/pro/rate_limiting.md
+++ b/docs/pro/rate_limiting.md
@@ -71,6 +71,40 @@ Add a `total` bucket alongside `default` if you want a hard cap on the combined 
 
 From this baseline you can tighten specific commands by adding explicit buckets — for example, lowering `publish` or `history` limits — without touching the rest. The sections below describe the full per-command configuration.
 
+## Try limits before enforcing them
+
+The hardest part of rate limiting is picking numbers. Set them too low and you break normal users; set them too high and they protect nothing. Guessing is avoidable — every layer supports `dry_run`:
+
+```json title="config.json"
+{
+  "client": {
+    "rate_limit": {
+      "client_command": {
+        "enabled": true,
+        "dry_run": true,
+        "default": {
+          "enabled": true,
+          "buckets": [{"interval": "1s", "rate": 100}]
+        }
+      }
+    }
+  }
+}
+```
+
+In dry run Centrifugo evaluates buckets and consumes tokens exactly as it would when enforcing, records every over-limit hit to metrics, and then **allows the operation anyway**. Nothing is ever rejected.
+
+That makes the rollout a measurement rather than a bet:
+
+1. Enable the layer with `dry_run: true` and your candidate buckets.
+2. Watch `centrifugo_rate_limit_client_over_limit_count` (see [Metrics](#metrics)) for a representative period — at least one full daily traffic cycle.
+3. If real users are producing hits, the limit is too tight. Raise it and keep watching.
+4. When the counter only moves for traffic you actually want to stop, remove `dry_run`.
+
+Because dry run drains the same buckets, the counter reports precisely what enforcement would have rejected — switching it off changes the verdict, not the accounting.
+
+`dry_run` is available on `client_command`, `user_command`, `redis_user_command`, `client_error` and `ip_connect`, and can be set per layer. It defaults to `false`, so existing configurations keep enforcing.
+
 ## In-memory per connection rate limit
 
 In-memory rate limit is an efficient way to limit the number of operations allowed on a per-connection basis – i.e. inside each individual real-time connection. Our rate limit implementation uses the [token bucket](https://en.wikipedia.org/wiki/Token_bucket) algorithm internally.
@@ -91,9 +125,11 @@ The list of operations which can be rate limited on a per-connection level is:
 * `track`
 * `untrack`
 
+`unsubscribe` and `untrack` behave differently from the rest: their buckets are charged and reported, but exceeding them never rejects the command. See [Commands that are counted but never rejected](#commands-that-are-counted-but-never-rejected).
+
 In addition, Centrifugo allows defining two special buckets containers:
 
-* `total` – define it to cap the combined rate of all commands from a connection. Total buckets are checked after the per-command (or `default`) check passes — only allowed commands consume a token from `total`. Rejected commands do not count against `total`. Note: `connect` is not subject to `total` in `client_command` (connect is not throttled at the per-connection level at all).
+* `total` – define it to cap the combined rate of all commands from a connection. Total buckets are checked after the per-command (or `default`) check passes — only allowed commands consume a token from `total`. Rejected commands do not count against `total`. Note: `connect` is not subject to `total` in `client_command` (connect is not throttled at the per-connection level at all; see [Per-IP connect rate limit](#per-ip-connect-rate-limit)). `unsubscribe` and `untrack` are always allowed and therefore always consume `total` — see [Commands that are counted but never rejected](#commands-that-are-counted-but-never-rejected).
 * `default` - define it if you don't want to configure some command buckets explicitly, default buckets will be used in case command buckets is not configured explicitly.
 
 ```json title="config.json"
@@ -166,7 +202,7 @@ Centrifugo real-time SDKs are written in a way that if a client receives an erro
 
 Another type of rate limit in Centrifugo PRO is a per-user-ID in-memory rate limit. Like the per-client rate limit, this one is also very efficient since it also uses in-memory token buckets. The difference is that instead of rate limiting per individual client, this type of rate limit takes the user ID into account.
 
-This type of rate limit only checks commands coming from authenticated users – i.e. with a non-empty user ID set. Requests from anonymous users can't be rate limited with it.
+This type of rate limit only checks commands coming from authenticated users – i.e. with a non-empty user ID set. Requests from anonymous users can't be rate limited with it, since there is no user ID to aggregate on. Anonymous connections are covered per connection by `client_command`, and bounded in aggregate by [Per-IP connect rate limit](#per-ip-connect-rate-limit).
 
 The list of operations which can be rate limited is similar to the in-memory rate limit described above. But with **additional** `connect` method:
 
@@ -244,14 +280,13 @@ The configuration is very similar:
 
 The next type of rate limit in Centrifugo PRO is a distributed per-user-ID rate limit with Redis as a bucket state storage. In this case, limits are global for the entire Centrifugo cluster. If one user executed two commands on different Centrifugo nodes, Centrifugo consumes two tokens from the same bucket kept in Redis. Since this rate limit goes to Redis to check limits, it adds some latency to command processing. Our implementation tries to provide good throughput characteristics though – in our tests a single Redis instance can handle more than 100k limit check requests per second. And it's possible to scale Redis in the same ways as for the Centrifugo Redis Engine.
 
-This type of rate limit only checks commands coming from authenticated users – i.e. with a non-empty user ID set. Requests from anonymous users can't be rate limited with it. The implementation also uses the [token bucket](https://en.wikipedia.org/wiki/Token_bucket) algorithm internally.
+This type of rate limit only checks commands coming from authenticated users – i.e. with a non-empty user ID set. Requests from anonymous users can't be rate limited with it; see [Per-IP connect rate limit](#per-ip-connect-rate-limit) for the layer that does cover them. The implementation also uses the [token bucket](https://en.wikipedia.org/wiki/Token_bucket) algorithm internally.
 
-The list of operations which can be rate limited is similar to the in-memory user command rate limit described above. But **without** special bucket `total`:
+The list of operations which can be rate limited is similar to the in-memory user command rate limit described above. But **without** special bucket `total`, and without `unsubscribe` and `untrack` (see [Commands that are counted but never rejected](#commands-that-are-counted-but-never-rejected)):
 
 * `default`
 * `connect`
 * `subscribe`
-* `unsubscribe`
 * `publish`
 * `history`
 * `presence`
@@ -262,7 +297,6 @@ The list of operations which can be rate limited is similar to the in-memory use
 * `map_publish`
 * `map_remove`
 * `track`
-* `untrack`
 
 The configuration is very similar:
 
@@ -346,7 +380,9 @@ In this case the rate limit will simply connect to Redis instances configured fo
 
 ## Performance
 
-**In-memory throttlers** (`client_command` and `user_command`) check token buckets entirely in memory with zero allocations per check. A single bucket check costs around **50 ns** on modern hardware; stacking multiple buckets or adding `total` adds only a few nanoseconds each. The overhead is negligible compared to normal command processing.
+**In-memory throttlers** (`client_command` and `user_command`) check token buckets entirely in memory with zero allocations per check. A single bucket check costs around **50 ns** on modern hardware; stacking multiple buckets or adding `total` adds only a few nanoseconds each. A full channel command through one layer — namespace resolution plus a per-command bucket and `total` — costs about **130 ns** with no allocations, and both in-memory layers chained cost about **260 ns**. A build with rate limits switched off pays a single branch, around **4 ns**.
+
+**Per-IP connect limit** (`ip_connect`) is one in-memory bucket check per connection *attempt*, around **43 ns**, and does not touch the per-command path at all.
 
 **Redis throttler** (`redis_user_command`) executes one Lua script call to Redis per command. In production there is always parallelism from many concurrent connections, so the relevant figure is aggregate throughput: benchmarks against a local Redis instance with 64 concurrent goroutines show **~260k checks/s** (~4 µs/op). A single Redis node can comfortably handle this load, and Centrifugo supports the same Redis scaling options as the engine (Sentinel, Cluster, client-side sharding) to go further.
 
@@ -356,13 +392,116 @@ Use a dedicated Redis instance for rate limiting rather than reusing the engine 
 
 :::
 
-When all three throttler layers are active they run in sequence, short-circuiting on the first denial. The two in-memory layers contribute under 200 ns combined; the Redis layer contributes one Redis round-trip. Use the in-memory throttlers alone when per-node limits are sufficient, and add the Redis throttler when limits must be consistent across the Centrifugo cluster.
+When all three throttler layers are active they run in sequence, short-circuiting on the first denial. The two in-memory layers contribute under 300 ns combined; the Redis layer contributes one Redis round-trip. Use the in-memory throttlers alone when per-node limits are sufficient, and add the Redis throttler when limits must be consistent across the Centrifugo cluster.
 
 :::tip
 
 Use `user_command` as a cheap front-end filter for `redis_user_command`. Because in-memory checks run first and short-circuit on denial, configuring the same (or slightly looser) limits in `user_command` means that over-limit requests are caught in memory before they ever reach Redis. Only requests that pass the in-memory gate incur a Redis round-trip. This can significantly reduce Redis load from abusive or misbehaving clients hammering a single node.
 
 :::
+
+## Commands that are counted but never rejected
+
+`unsubscribe` and `untrack` are treated differently from every other command: their buckets are charged and reported, but exceeding them **never rejects the command**.
+
+This is deliberate, and it is about load rather than leniency. Both commands exist for a client to shed state it no longer wants — leaving a channel, dropping a tracked key — so server-side work goes *down* when they succeed. Refusing them inverts that:
+
+* Every Centrifugo SDK treats an error reply to `unsubscribe` as fatal and reconnects. So rejecting one cheap command produces a full reconnect instead: a new transport, a connect handshake, token verification, a connect proxy call if configured, and a resubscribe to every channel. Under load that turns a rate limit into a reconnect storm.
+* A rejected `untrack` leaves the server tracking a key the client has already forgotten, so it keeps broadcasting updates nobody wants. Load goes up and the two sides disagree permanently.
+
+Protection is not lost, because these commands still consume tokens — including from `total`, and unlike enforced commands they consume it even when their own bucket is empty. A flood of unsubscribes therefore drains the connection's overall budget, and the commands that *do* ask the server to do work (`publish`, `history`, `presence`, `rpc`, `subscribe`) start being rejected instead. Rejection still happens; it happens where an SDK handles it sanely.
+
+Their buckets remain useful as a **detection** signal. Configure `unsubscribe` at a rate no real client should reach and alert on the metric:
+
+```json title="config.json"
+{
+  "client": {
+    "rate_limit": {
+      "client_command": {
+        "enabled": true,
+        "unsubscribe": {
+          "enabled": true,
+          "buckets": [{"interval": "1s", "rate": 50}]
+        }
+      }
+    }
+  }
+}
+```
+
+Over-limit hits show up as `centrifugo_rate_limit_client_over_limit_count{command="unsubscribe"}` and mean "this connection is behaving abnormally", not "this command was refused".
+
+:::note
+
+For the same reason, `unsubscribe` and `untrack` are not evaluated by the `redis_user_command` layer. That layer has no `total` bucket to accumulate into and never rejects these commands, so a Redis round trip per unsubscribe would buy nothing. They are charged by the two in-memory layers.
+
+:::
+
+## Per-IP connect rate limit
+
+Every layer above keys on a client ID or a user ID, which means none of them can act until a connection exists and — for the per-user layers — until it has authenticated. Two things fall outside that:
+
+* **Anonymous connections.** With `client.allow_anonymous` there is no user ID, so `user_command` and `redis_user_command` skip these connections entirely. `client_command` does apply, but it only sets the cost *per connection* — and the number of connections is the attacker's choice.
+* **Connect-time work.** A connect attempt verifies a JWT and, when the connect proxy is configured, makes an HTTP call to your backend. Both happen before there is any user ID to rate limit on, so a flood of unauthenticated connects reaches your backend at full rate.
+
+`ip_connect` closes both. It runs in HTTP middleware, before the connection handler, keyed on the client's address:
+
+```json title="config.json"
+{
+  "client": {
+    "rate_limit": {
+      "ip_connect": {
+        "enabled": true,
+        "buckets": [
+          {"interval": "1s", "rate": 10},
+          {"interval": "1m", "rate": 200}
+        ]
+      }
+    }
+  }
+}
+```
+
+An address over the limit gets an HTTP `429` before any connect work happens. Unlike a rejection inside the protocol, this is a response to a *connection attempt*, so SDKs apply their normal connect backoff rather than tearing down an established session.
+
+Options:
+
+* `enabled` – turns the layer on. Off by default.
+* `buckets` – token buckets, same format as everywhere else. All listed buckets must allow the attempt.
+* `dry_run` – evaluate and report without rejecting. Strongly recommended for the first rollout: this layer sits in front of every connection, so a number that is too low locks users out.
+* `max_tracked_ips` – how many addresses are tracked at once, default `100000`. Once reached, addresses that are not already tracked are **allowed through** rather than evicting live entries. Failing open is deliberate: rejecting unknown addresses at capacity would let an attacker fill the table with junk and deny service to everybody else.
+
+:::note
+
+Address derivation follows the same rules Centrifugo uses elsewhere: `X-Forwarded-For` and `X-Real-IP` are trusted **only** when the immediate socket peer is a loopback or private address, i.e. a local reverse proxy or load balancer. For a directly connected public client those headers are attacker-controlled and ignored, so a client cannot spoof them to evade its own limit or exhaust somebody else's bucket. If you terminate TLS on a public-IP load balancer that does not appear as a private peer, put a private-address proxy in front or rely on infrastructure-level limits instead.
+
+:::
+
+:::tip
+
+`ip_connect` complements the existing `client.connection_rate_limit`, which caps new connections per node *in aggregate*. An aggregate cap protects the node but treats all callers alike, so one flooding source can consume the whole budget and starve everyone else. A per-IP limit charges the source that is actually responsible. Using both is reasonable: per-IP for fairness, aggregate as a backstop.
+
+:::
+
+## Metrics
+
+Rate limit decisions are exported so you can see whether limits fire, which layer fired, and for which command:
+
+```
+centrifugo_rate_limit_client_over_limit_count{layer, command, namespace, dry_run}
+```
+
+* `layer` – `client_command`, `user_command`, `redis_user_command`, `client_error` or `ip_connect`.
+* `command` – the command that exceeded its bucket (`publish`, `subscribe`, `rpc.my_method`, `connect` for `ip_connect`, `error` for `client_error`).
+* `namespace` – the channel namespace, populated only when `prometheus.channel_namespace_resolution` is enabled, empty otherwise. This reuses the existing switch so cardinality stays bounded by the number of configured namespaces.
+* `dry_run` – `true` when the layer is in dry run, so hits recorded while sizing a limit are never confused with traffic that was actually rejected.
+
+The counter is incremented **only** when a bucket denies. Commands that pass their buckets do no metric work at all, so the normal path costs nothing.
+
+Two readings are worth alerting on:
+
+* Sustained hits with `dry_run="false"` mean real traffic is being rejected — either an attack, or a limit set too low.
+* Hits on `command="unsubscribe"` or `command="untrack"` mean a connection is behaving abnormally, since those commands are never actually rejected.
 
 ## Channel namespace overrides
 
@@ -491,6 +630,20 @@ The configuration on error limits per connection may look like this:
 ```
 
 If a client will have more than 20 protocol errors per 5 second – it will be disconnected.
+
+`client_error` also supports `dry_run`, which reports would-be disconnects to metrics (`layer="client_error"`) without ever disconnecting. Since this limit ends in a disconnect rather than a rejected command, sizing it in dry run first is worth the extra step.
+
+## Upgrade notes
+
+Three behaviours changed in the rate limit subsystem. All of them are safe by default — no new limit starts enforcing on upgrade — but two are worth checking if you already have limits configured.
+
+**`unsubscribe` and `untrack` are no longer rejected.** Previously an over-limit `unsubscribe` returned an error, which every SDK turns into a full reconnect. They are now charged and reported but always allowed. If you relied on the rejection, nothing replaces it directly — alert on the metric instead, and let the `total` bucket absorb floods. This strictly reduces rejections, so it cannot break a working deployment.
+
+**`unsubscribe` and `untrack` now work on the `user_command` layer.** They were documented and accepted as configuration but registered no buckets there, so setting them — or relying on `default` to cover them — silently did nothing. They now behave as documented. The practical consequence is that these commands consume the per-user `total` bucket where they previously consumed nothing. If your `user_command.total` is tight and your application swaps channels frequently, check the metric before and after upgrading, or run the layer with `dry_run: true` for a period first.
+
+**Server-initiated refreshes are no longer rate limited.** `refresh` and `sub_refresh` limits previously applied to Centrifugo's own subscription and connection expiry refreshes as well as to client-sent commands. Exhausting those buckets could therefore drop subscriptions or disconnect connections that had sent nothing. Only client-initiated refreshes are limited now. If you had raised these limits to work around unexplained disconnects, you can lower them again.
+
+Nothing in the configuration format changed incompatibly: `dry_run` defaults to `false` on every layer, and `ip_connect` is disabled unless configured.
 
 ## RPC method overrides format change
 

--- a/docs/pro/rate_limiting.md
+++ b/docs/pro/rate_limiting.md
@@ -524,7 +524,40 @@ Options:
 * `enabled` – turns the layer on. Off by default.
 * `buckets` – token buckets, same format as everywhere else. All listed buckets must allow the attempt.
 * `dry_run` – evaluate and report without rejecting. Strongly recommended for the first rollout: this layer sits in front of every connection, so a number that is too low locks users out.
+* `max_concurrent_per_ip` – how many connections one address may hold open at once. Zero (default) means no limit. **This is a different limit from the buckets above**, and both are needed — see below.
 * `max_tracked_ips` – how many addresses are tracked at once, default `100000`. Once reached, addresses that are not already tracked are **allowed through** rather than evicting live entries. Failing open is deliberate: rejecting unknown addresses at capacity would let an attacker fill the table with junk and deny service to everybody else.
+
+### Rate is not enough: cap concurrent connections too
+
+The buckets above bound how *fast* an address acquires connections. They do not bound how many it *holds*.
+
+Per-connection rate limits are per connection. An attacker that acquires slowly enough to stay under the rate limit and simply keeps the connections open multiplies its allowed command budget by the number it holds — without ever breaking a rule. Measured, acquiring at 4/s against a 5/s connect limit:
+
+| | no per-IP layer | rate + `max_concurrent_per_ip: 4` |
+|---|---:|---:|
+| connections held | 12 | **4** |
+| connect attempts refused | 0 | 12 |
+| effective command budget | **7.4×** the per-connection limit | **1.5×** |
+| server CPU | 5.74s | **140ms** |
+| legitimate p99 | 4.17ms | **406µs** |
+
+Scaled up, this is also how a single address exhausts `client.connection_limit` and denies service to everybody else. Set both:
+
+```json title="config.json"
+{
+  "client": {
+    "rate_limit": {
+      "ip_connect": {
+        "enabled": true,
+        "buckets": [{"interval": "1s", "rate": 10}],
+        "max_concurrent_per_ip": 20
+      }
+    }
+  }
+}
+```
+
+Size `max_concurrent_per_ip` against your own users, not against attackers: several browser tabs, a mobile app reconnecting while the old socket is still closing, and users sharing an office NAT all legitimately hold more than one connection. If you terminate at a proxy that does not forward the client address, every user appears as one address and this limit is not usable — leave it at zero.
 
 :::note
 

--- a/docs/pro/rate_limiting.md
+++ b/docs/pro/rate_limiting.md
@@ -448,6 +448,24 @@ Disconnecting is not the same as refusing. The disconnect code is in the range t
 
 It is off by default, and worth sizing carefully: a client doing legitimate rapid channel churn must not be cut off by a bucket set too tight. Run with `dry_run: true` first and watch the metric before enabling it. The decision is made per connection — the per-user layer never disconnects, since one abusive session must not take down a user's other sessions.
 
+:::caution Requires a connect rate limit
+
+**Disconnecting only works if something meters how fast the client is allowed back.** An attacker does not use an SDK, so it ignores the advice not to reconnect — and every reconnect gives it a new client ID and therefore a fresh set of per-connection buckets.
+
+Measured at 1M unsubscribe frames/s from a client that always reconnects:
+
+| | no limits | disconnect only | disconnect + `ip_connect` |
+|---|---:|---:|---:|
+| frames delivered/s | 499.4k | 420.1k | **1.1k** |
+| reconnects won | 8 | 1547 | 14 |
+| server CPU | 5.46s | 5.31s | **710ms** |
+| legitimate p99 | 359ms | 10.07ms | **707µs** |
+| flood stopped | — | **15.9%** | **99.8%** |
+
+Enable [`ip_connect`](#per-ip-connect-rate-limit) alongside it, or enforce a per-IP connection rate in your infrastructure. Centrifugo logs a warning at startup if `disconnect_on_accounted_limit` is set without `ip_connect` configured.
+
+:::
+
 Their buckets are also useful as a pure **detection** signal. Configure `unsubscribe` at a rate no real client should reach and alert on the metric:
 
 ```json title="config.json"


### PR DESCRIPTION
Documents the rate limiting rework in [centrifugo-pro-source#263](https://github.com/centrifugal/centrifugo-pro-source/pull/263). Should land together with it.

## New sections

- **Try limits before enforcing them** — `dry_run` on every layer, and the observe-then-enforce workflow it makes possible. Placed early, because picking numbers is the hard part of rate limiting and it no longer has to be a guess.
- **Commands that are counted but never rejected** — why `unsubscribe` and `untrack` are charged but always allowed (rejecting them raises load: SDKs reconnect on an unsubscribe error, and a refused untrack leaves the server broadcasting a key the client has forgotten), and why protection is not lost.
- **Per-IP connect rate limit** — the pre-authentication layer, what it covers that nothing else can (anonymous connections; connect-time work including the connect proxy call), the `max_tracked_ips` bound and why it fails open, and the forwarded-header trust rules.
- **Metrics** — `centrifugo_rate_limit_client_over_limit_count`, its labels, and the two readings worth alerting on.
- **Upgrade notes** — the three behaviour changes, all safe by default.

## Updated

- Both per-user sections now explain *why* anonymous traffic is invisible to them, and link to the layer that covers it.
- The `redis_user_command` command list drops `unsubscribe` and `untrack` — that layer no longer evaluates them, since it has no `total` to accumulate into and never rejects them.
- The `total` bucket description covers the accounted-only commands.
- Performance numbers refreshed from current benchmarks, plus the per-IP layer.
- `client_error` gains a `dry_run` note, since that limit ends in a disconnect rather than a rejected command.

All in-page anchors verified to resolve.

## Follow-up worth considering

The load measurement in the code PR turned up something the docs should probably say out loud, but I have not written it yet because it is a guidance change rather than a description of new options:

**Command limits alone do not protect CPU.** With attackers flooding at full rate, per-connection command limits cut broker load 597× but left CPU unchanged (20.03s → 20.11s) — every hostile frame is still decoded and dispatched before being refused. Adding `client_error` (to shed the connection) and `ip_connect` (to make coming back expensive) took CPU to 160ms, a 125× reduction, and *improved* legitimate p99 latency from 476µs to 68µs.

The "Disconnecting abusive or misbehaving connections" section currently presents `client_error` as an optional extra. On this evidence it is the layer that actually protects the server, and the three should be recommended together. Happy to write that up if you agree with the framing.
